### PR TITLE
Add option to verify SSL cert.

### DIFF
--- a/src/metasploit/msfrpc.py
+++ b/src/metasploit/msfrpc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from httplib import HTTPConnection, HTTPSConnection
+import ssl
 from numbers import Number
 
 from msgpack import packb, unpackb
@@ -194,14 +195,19 @@ class MsfRpcClient(object):
         - port : the remote msfrpcd port to connect to (default: 55553)
         - server : the remote server IP address hosting msfrpcd (default: localhost)
         - ssl : if true uses SSL else regular HTTP (default: SSL enabled)
+        - verify : if true, verify SSL cert when using SSL (default: False)
         """
         self.uri = kwargs.get('uri', '/api/')
         self.port = kwargs.get('port', 55553)
         self.server = kwargs.get('server', '127.0.0.1')
         self.ssl = kwargs.get('ssl', True)
+        self.verify_ssl = kwargs.get('verify', False)
         self.sessionid = kwargs.get('token')
         if self.ssl:
-            self.client = HTTPSConnection(self.server, self.port)
+            if self.verify_ssl:
+                self.client = HTTPSConnection(self.server, self.port)
+            else:
+                self.client = HTTPSConnection(self.server, self.port, context=ssl._create_unverified_context())
         else:
             self.client = HTTPConnection(self.server, self.port)
         self.login(kwargs.get('username', 'msf'), password)


### PR DESCRIPTION
Adds 'verify' option MsfRpcClient constructor. Setting to true will enforce SSL cert verification. Disabled by default since it's most likely self-signed.