### PR TITLE
fix bad chars in prompt

### DIFF
--- a/src/scripts/pymsfconsole
+++ b/src/scripts/pymsfconsole
@@ -50,11 +50,10 @@ class MsfConsole(InteractiveConsole):
     def callback(self, d):
         stdout.write('\n%s' % d['data'])
         if not self.fl:
-            stdout.write('\n%s' % d['prompt'])
+            stdout.write('\n%s' % d['prompt'].replace("\x01\x02", ""))
             stdout.flush()
         else:
             self.fl = False
-
 
 if __name__ == '__main__':
     o = parseargs()


### PR DESCRIPTION
The prompt colouring comes out of msfrpcd as \x01\x02, this change removes these characters from the prompt.
This could potentially be a bug in msfrpcd itself...
