### PR TITLE
Create msfrpcdHandler.py

### DIFF
--- a/src/metasploit/msfrpcdHandler.py
+++ b/src/metasploit/msfrpcdHandler.py
@@ -1,0 +1,28 @@
+# Handles the MetaSploit Framework Remote Procedure Call Daemon (MSFRPCD) for *nix machines
+
+import os, psutil, signal, time
+
+def msfrpcdStart(password):
+	if checkMsfrpcdRunning(): return "MetaSploit Framework Remote Procedure Call Daemon is already running."
+	else:
+		response = os.system("msfrpcd -P "+password+" -n -a 127.0.0.1")
+		time.sleep(10)
+		if checkMsfrpcdRunning(): return "MetaSploit Framework Remote Procedure Call Daemon running."
+		else: return "There was an issue: MetaSploit Framework Remote Procedure Call Daemon did not start."
+
+def checkMsfrpcdRunning():
+	for socket in psutil.net_connections():
+		if socket.laddr[1] == 55553: return socket.pid
+
+def msfrpcdRestart(password):
+	pid = checkMsfrpcdRunning()
+	if pid:
+		os.kill(socket.pid, signal.SIGKILL)
+		print "Old MSFRPCD process killed."
+	response = os.system("msfrpcd -P "+password+" -n -a 127.0.0.1")
+	time.sleep(10)
+	if checkMsfrpcdRunning(): return "MetaSploit Framework Remote Procedure Call Daemon running."
+	else: return "There was an issue: MetaSploit Framework Remote Procedure Call Daemon did not start."
+			
+if __name__ == "__main__":
+	print msfrpcdStart('pass123')


### PR DESCRIPTION
When using PyMetasploit, I normally run a handler to check if the MSFRPCD is already running, otherwise if I forger to check netstat I throw an error in my console when starting the service out of habit. This small bit of functionality would allow users to start the service and handle if it is already running, as well as be able to restart it if there is a connectivity issue later on. 