### PR TITLE
Removed check for DisablePayloadHandler in msfrpc.

### DIFF
--- a/src/metasploit/msfrpc.py
+++ b/src/metasploit/msfrpc.py
@@ -1450,9 +1450,7 @@ class MsfModule(object):
         if isinstance(self, ExploitModule):
             payload = kwargs.get('payload')
             runopts['TARGET'] = self.target
-            if 'DisablePayloadHandler' in runopts and runopts['DisablePayloadHandler']:
-                pass
-            elif payload is None:
+            if payload is None:
                 runopts['DisablePayloadHandler'] = True
             else:
                 if isinstance(payload, PayloadModule):


### PR DESCRIPTION
DisablePayloadHandler is an option in metasploit to use an existing handler that is already running. At the moment it is interpreted as DisablePayload. This is not the right functionality. This pull request fixes this issue by removing the check for DisablePayloadHandler.
