### PR TITLE
metasploit API correction

### DIFF
--- a/src/metasploit/msfrpc.py
+++ b/src/metasploit/msfrpc.py
@@ -1822,7 +1822,7 @@ class ShellSession(MsfSession):
         """
         Read data from the shell session.
         """
-        return self.rpc.call(MsfRpcMethod.SessionShellRead, self.id)['data']
+        return self.rpc.call(MsfRpcMethod.SessionShellRead, self.id).get(b'write_count')
 
     def write(self, data):
         """

--- a/src/metasploit/msfrpc.py
+++ b/src/metasploit/msfrpc.py
@@ -1328,8 +1328,12 @@ class MsfModule(object):
         self.modulename = mname
         self.rpc = rpc
         self._info = rpc.call(MsfRpcMethod.ModuleInfo, mtype, mname)
+        property_attributes = ["advanced", "evasion", "options", "required",
+                               "runoptions"]
         for k in self._info:
-            setattr(self, k, self._info.get(k))
+            if k not in property_attributes:
+                # don't try to set property attributes
+                setattr(self, k, self._info.get(k))
         self._moptions = rpc.call(MsfRpcMethod.ModuleOptions, mtype, mname)
         self._roptions = []
         self._aoptions = []


### PR DESCRIPTION
due to metasploit 4.17.6 evolution in API, 
*warning* metasploit still not working due to regression , 
https://github.com/rapid7/metasploit-framework/commit/730010aa06699b4659741fec7ae9b800e4ede926#diff-978d10acde1c556e3f73ac0df288e9fa